### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/syed21000/6067cbfd-2245-4bae-b434-b0f89fd12926/5f327fc1-8238-4420-a33e-94da7058f09c/_apis/work/boardbadge/02ced6db-5ed7-4890-a366-9fab009f5666)](https://dev.azure.com/syed21000/6067cbfd-2245-4bae-b434-b0f89fd12926/_boards/board/t/5f327fc1-8238-4420-a33e-94da7058f09c/Microsoft.RequirementCategory)
 # SD-Project
 A Project for Software Delivery Project


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/syed21000/6067cbfd-2245-4bae-b434-b0f89fd12926/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.